### PR TITLE
Fix contact link anchors

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -17,7 +17,7 @@
           <li><a href="faq.html" aria-current="page">FAQ</a></li>
           <li><a href="garantie.html">Garantie</a></li>
           <li><a href="rechtliches.html">Impressum & Datenschutz</a></li>
-          <li><a href="index.html#contact" class="btn btn-primary">Termin</a></li>
+          <li><a href="index.html#kontakt" class="btn btn-primary">Termin</a></li>
         </ul>
       </nav>
     </div>

--- a/garantie.html
+++ b/garantie.html
@@ -17,7 +17,7 @@
           <li><a href="faq.html">FAQ</a></li>
           <li><a href="garantie.html" aria-current="page">Garantie</a></li>
           <li><a href="rechtliches.html">Impressum & Datenschutz</a></li>
-          <li><a href="index.html#contact" class="btn btn-primary">Termin</a></li>
+          <li><a href="index.html#kontakt" class="btn btn-primary">Termin</a></li>
         </ul>
       </nav>
     </div>

--- a/preise.html
+++ b/preise.html
@@ -17,7 +17,7 @@
           <li><a href="faq.html">FAQ</a></li>
           <li><a href="garantie.html">Garantie</a></li>
           <li><a href="rechtliches.html">Impressum & Datenschutz</a></li>
-          <li><a href="index.html#contact" class="btn btn-primary">Termin</a></li>
+          <li><a href="index.html#kontakt" class="btn btn-primary">Termin</a></li>
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- fix navigation links that pointed to `#contact` instead of existing `#kontakt` section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a23461030c83208ca67dcf06d2ce74