### PR TITLE
Add optimized logo image

### DIFF
--- a/bilder/threpair-logo.svg
+++ b/bilder/threpair-logo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 90">
+  <style>
+    .primary { fill: #7ec9f7; }
+    .white { fill: #ffffff; }
+  </style>
+  <circle cx="60" cy="40" r="38" class="primary" opacity=".3"/>
+  <circle cx="60" cy="40" r="28" class="primary"/>
+  <rect x="52" y="22" width="16" height="30" rx="2" class="white"/>
+  <rect x="55" y="26" width="10" height="22" rx="1" class="primary" opacity=".3"/>
+  <circle cx="60" cy="48" r="1.5" class="primary"/>
+  <path d="M10 60h100v20H10z" class="primary"/>
+  <text x="60" y="74" font-family="Arial, sans-serif" font-size="14" text-anchor="middle" fill="#fff">TH REPAIR</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -12,8 +12,7 @@
         <div class="container">
             <div class="header-content">
                 <div class="logo">
-                    <div class="logo-icon">🔧</div>
-                    <span>TH Repair</span>
+                    <img src="bilder/threpair-logo.svg" alt="TH Repair Logo" class="logo-image">
                 </div>
             </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -49,23 +49,13 @@ header {
 }
 
 .logo {
-    font-size: 28px;
-    font-weight: bold;
     display: flex;
     align-items: center;
-    gap: 10px;
 }
 
-.logo-icon {
-    width: 50px;
-    height: 50px;
-    border: 2px solid var(--accent-color); /* outline */
-    border-radius: 10px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 35px;
-    background-color: var(--accent-color); /* makes the icon match the border */
+.logo-image {
+    height: 60px;
+    width: auto;
 }
 
 /* Hero Section */


### PR DESCRIPTION
## Summary
- Replace header emoji with SVG logo
- Style logo for consistent header sizing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aae9d57d308320902182d753215bca