### PR TITLE
Fix grammar and spelling across site

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
                 <div class="service-card">
                     <span class="service-icon">📱</span>
                     <h3>Smartphone-Reparatur</h3>
-                    <p>Display, Akku, Ladebuchse, Kamera und mehr für Apple, Samsung, Huawei, Xiaomi</p>
+                    <p>Display, Akku, Ladebuchse, Kamera und mehr – für Apple, Samsung, Huawei und Xiaomi</p>
                 </div>
                 <div class="service-card">
                     <span class="service-icon">🛍️</span>
@@ -64,7 +64,7 @@
                 <div class="service-card">
                     <span class="service-icon">🎯</span>
                     <h3>Zubehör &amp; Ersatzteile</h3>
-                    <p>Kabel, Hüllen, Schutzfolien und mehr - alles für dein Gerät</p>
+                    <p>Kabel, Hüllen, Schutzfolien und mehr – alles für dein Gerät</p>
                 </div>
                 <div class="service-card">
                     <span class="service-icon">💬</span>
@@ -146,9 +146,9 @@
             <h2>📅 Jetzt Termin vereinbaren</h2>
             <p class="contact-subheading">Am schnellsten erreichst du mich über WhatsApp</p>
             <div class="contact-buttons">
-                <a href="https://wa.me/491601845755" class="whatsapp-button">
-                    📲 WhatsApp Schreiben!
-                </a>
+                  <a href="https://wa.me/491601845755" class="whatsapp-button">
+                      📲 Über WhatsApp schreiben
+                  </a>
                 <a href="https://www.kleinanzeigen.de/s-bestandsliste.html?userId=137900326" class="secondary-button">
                     🛍️ Kleinanzeigen
                 </a>

--- a/rechtliches.html
+++ b/rechtliches.html
@@ -28,7 +28,7 @@
 </header>
 <main class="section">
   <h1>Impressum</h1>
-  <p>Tjerk Heinenbernd<br>Röringhoff 11<br>48691 Vreden<br>Tel: 0160 1845755<br>Email: info@threpair.de</p>
+  <p>Tjerk Heinenbernd<br>Röringhoff 11<br>48691 Vreden<br>Tel.: 0160 1845755<br>E-Mail: info@threpair.de</p>
   <h2>Datenschutzerklärung</h2>
   <p>Diese Webseite nutzt keine Cookies. Kontakt über WhatsApp, Telefon oder E-Mail erfolgt freiwillig. Es gelten die Bestimmungen der DSGVO.</p>
 </main>


### PR DESCRIPTION
## Summary
- Improve service descriptions with clearer punctuation
- Rephrase WhatsApp contact button text
- Standardize contact details on the legal page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaebc9991883209a1f9a81066802c0