### PR TITLE
Remove cookie consent popup and auto-load third-party embeds

### DIFF
--- a/script.js
+++ b/script.js
@@ -10,62 +10,13 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const cookieBanner = document.querySelector('[data-cookie-banner]');
-  const acceptButton = document.querySelector('[data-cookie-accept], [data-accept]');
-  const consentKey = 'threpair_cookie_choice';
-
-  const hideBanner = () => {
-    if (cookieBanner) {
-      cookieBanner.hidden = true;
-      cookieBanner.setAttribute('aria-hidden', 'true');
-    }
-    document.body.classList.remove('consent-required');
-  };
-
-  const showBanner = () => {
-    if (cookieBanner) {
-      cookieBanner.hidden = false;
-      cookieBanner.setAttribute('aria-hidden', 'false');
-    }
-    document.body.classList.add('consent-required');
-  };
-
-  const storeConsent = (value) => {
-    try {
-      localStorage.setItem(consentKey, value);
-    } catch (error) {
-      console.warn('Consent konnte nicht gespeichert werden.', error);
-    }
-    if (value === 'accepted') {
-      activateThirdPartyEmbeds();
-    }
-    hideBanner();
-  };
-
-  const getConsent = () => {
-    try {
-      return localStorage.getItem(consentKey);
-    } catch (error) {
-      return null;
-    }
-  };
 
   if (cookieBanner) {
-    const storedConsent = getConsent();
-    if (storedConsent !== 'accepted') {
-      showBanner();
-    } else {
-      hideBanner();
-      activateThirdPartyEmbeds();
-    }
+    cookieBanner.hidden = true;
+    cookieBanner.setAttribute('aria-hidden', 'true');
   }
-
-  if (acceptButton) {
-    acceptButton.addEventListener('click', () => storeConsent('accepted'));
-  }
-
-  document.querySelectorAll('[data-open-consent]').forEach((button) => {
-    button.addEventListener('click', () => showBanner());
-  });
+  document.body.classList.remove('consent-required');
+  activateThirdPartyEmbeds();
 
   function activateThirdPartyEmbeds() {
     document.querySelectorAll('[data-consent-embed]').forEach((box) => {

--- a/styles.css
+++ b/styles.css
@@ -251,13 +251,7 @@ iframe { border: 0; width: 100%; }
 .footer-note { width:100%; color: var(--muted); font-size: .9rem; }
 
 .cookie-banner {
-  position: fixed; inset: 0; z-index: 500;
-  display: flex; align-items: center; justify-content: center;
-  padding: 20px;
-  background: rgba(15, 23, 42, 0.55);
-}
-.cookie-banner[hidden] {
-  display: none;
+  display: none !important;
 }
 .cookie-banner > * {
   width: min(860px, 100%);


### PR DESCRIPTION
### Motivation
- Remove the blocking cookie-consent popup and its gating behavior so the site no longer interrupts users with the banner. 
- Auto-load third-party embeds (maps/widgets) immediately instead of waiting for a stored consent choice.

### Description
- Removed consent storage and banner show/hide logic from `script.js` and eliminated the `data-cookie-accept` and `data-open-consent` handlers. 
- Always hide the cookie banner on load and call `activateThirdPartyEmbeds()` unconditionally in `script.js` so `data-consent-embed` boxes are filled automatically. 
- Added a CSS hard-hide (`display: none !important`) for `.cookie-banner` in `styles.css` to prevent the popup from appearing if JavaScript is disabled. 
- Changes applied to `script.js` and `styles.css`.

### Testing
- Ran `node --check script.js` to validate JavaScript syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb183cd2448320b763cde0fccf2422)